### PR TITLE
Found image fix! And some CSS cleanup

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -52,14 +52,14 @@ body {
 
 /* ---------------------------- Header */
 
-.main-content header {
+header {
   text-align: center;
   font-family: 'Dancing Script', serif;
   font-size: 26px;
   color: #818181;
 }
 
-.main-content header a {
+header a {
   text-decoration: none;
   color: #818181;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,5 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Dancing+Script:wght@400;500;700&family=Lora:wght@400;500;700&display=swap');
 
+/* ---------------------------- General Rules */
 * {
   padding: 0;
   margin: 0;
@@ -19,7 +20,7 @@ body {
   min-height: 100%;
 }
 
-/* Sidenav */
+/* ---------------------------- Sidenav */
 
 .sidenav {
   height: 100%;
@@ -49,21 +50,22 @@ body {
   display: block;
 }
 
-/* Header */
+/* ---------------------------- Header */
 
 .main-content header {
   text-align: center;
+  font-family: 'Dancing Script', serif;
+  font-size: 26px;
+  color: #818181;
 }
 
 .main-content header a {
   text-decoration: none;
   color: #818181;
-  font-family: 'Dancing Script', sans-serif;
-  font-size: 26px;
 }
 
 
-/* Hero image */
+/* ---------------------------- Hero Image */
 
 .hero-image {
   width: 100%;
@@ -71,13 +73,15 @@ body {
   background: url('../images/belgian-bakes-hero-image.png') no-repeat center center/cover;
 }
 
-/* Main Content */
+/* ---------------------------- Main Content */
 
 
 .main-content {
   margin-right: 160px;
   margin-bottom: 10px;
   padding: 0px 10px;
+
+  font-family: 'Lora', sans-serif;
 }
 
 .main-content .hero-image {
@@ -97,15 +101,8 @@ body {
   border-radius: 4px;
 }
 
-
-
 .main-content .category a h2 {
-  font-family: 'Lora', sans-serif;
   margin-bottom: 6px;
-}
-
-.main-content .category a p {
-  font-family: 'Lora', sans-serif;
 }
 
 .main-content .category a {
@@ -123,7 +120,7 @@ body {
   margin-bottom: 5px;
 }
 
-/* Footer */
+/* ---------------------------- Footer */
 
 footer {
   position: absolute;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,147 +1,155 @@
 @import url('https://fonts.googleapis.com/css2?family=Dancing+Script:wght@400;500;700&family=Lora:wght@400;500;700&display=swap');
 
 * {
-    padding: 0;
-    margin: 0;
-    box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
 }
 
 html {
-    height: 100%;
-    overflow-x: hidden;
+  height: 100%;
+  overflow-x: hidden;
 }
 
 body {
-    background-color: #fccfbf;
-    position: relative;
-    margin: 0;
-    padding-bottom: 4rem;
-    min-height: 100%;
+  background-color: #fccfbf;
+  position: relative;
+  margin: 0;
+  padding-bottom: 4rem;
+  min-height: 100%;
 }
 
 /* Sidenav */
 
 .sidenav {
-    height: 100%; /* Full-height: remove this if you want "auto" height */
-    width: 160px; /* Set the width of the sidebar */
-    position: fixed; /* Fixed Sidebar (stay in place on scroll) */
-    z-index: 1; /* Stay on top */
-    top: 0; /* Stay at the top */
-    right: 0;
-    background-color: #111; /* Black */
-    overflow-x: hidden; /* Disable horizontal scroll */
-    padding-top: 20px;
-  }
+  height: 100%;
+  /* Full-height: remove this if you want "auto" height */
+  width: 160px;
+  /* Set the width of the sidebar */
+  position: fixed;
+  /* Fixed Sidebar (stay in place on scroll) */
+  z-index: 1;
+  /* Stay on top */
+  top: 0;
+  /* Stay at the top */
+  right: 0;
+  background-color: #111;
+  /* Black */
+  overflow-x: hidden;
+  /* Disable horizontal scroll */
+  padding-top: 20px;
+}
 
-  /* The navigation menu links */
+/* The navigation menu links */
 .sidenav a {
-    padding: 6px 8px 6px 16px;
-    text-decoration: none;
-    font-size: 25px;
-    color: #818181;
-    display: block;
-  }
+  padding: 6px 8px 6px 16px;
+  text-decoration: none;
+  font-size: 25px;
+  color: #818181;
+  display: block;
+}
 
-  /* Hero image */
+/* Header */
 
-  .hero-image {
-    width: 100%;
-    height: 250px;
-    background: url('../images/belgian-bakes-hero-image.png') no-repeat center center/cover;
-  }
+.main-content header {
+  text-align: center;
+}
 
-  /* Main Content */
+.main-content header a {
+  text-decoration: none;
+  color: #818181;
+  font-family: 'Dancing Script', sans-serif;
+  font-size: 26px;
+}
 
-  /* Header */
 
-  .main-content header {
-    text-align: center;
-  }
+/* Hero image */
 
-  .main-content header a {
-    text-decoration: none;
-    color: #818181;
-    font-family: 'Dancing Script', sans-serif;
-    font-size: 26px;
-  }
+.hero-image {
+  width: 100%;
+  height: 250px;
+  background: url('../images/belgian-bakes-hero-image.png') no-repeat center center/cover;
+}
 
-  .main-content {
-    margin-right: 160px;
-    margin-bottom: 10px;
-    padding: 0px 10px;
-  }
+/* Main Content */
 
-  .main-content .hero-image {
-    margin-bottom: 10px;
-  }
 
-  .category {
-    display: flex;
-    justify-content: space-around;
-    gap: 5px;
-  }
+.main-content {
+  margin-right: 160px;
+  margin-bottom: 10px;
+  padding: 0px 10px;
+}
 
-  .cat1,
-  .cat2,
-  .cat3 {
-    border: 2px solid #818181;
-    border-radius: 4px;
-  }
+.main-content .hero-image {
+  margin-bottom: 10px;
+}
 
-  .main-content .category .cat1 {
-    text-align: center;
-  }
+.category {
+  display: flex;
+  justify-content: space-around;
+  gap: 5px;
+}
 
-  .main-content .category .cat2 {
-    text-align: center;
-  }
+.cat1,
+.cat2,
+.cat3 {
+  border: 2px solid #818181;
+  border-radius: 4px;
+}
 
-  .main-content .category .cat3 {
-    text-align: center;
-  }
 
-  .main-content .category a h2 {
-    font-family: 'Lora', sans-serif;
-    margin-bottom: 6px;
-  }
 
-  .main-content .category a p {
-    font-family: 'Lora', sans-serif;
-  }
+.main-content .category a h2 {
+  font-family: 'Lora', sans-serif;
+  margin-bottom: 6px;
+}
 
-  .main-content .category a {
-    text-decoration: none;
-    color: #818181;
+.main-content .category a p {
+  font-family: 'Lora', sans-serif;
+}
 
-  }
+.main-content .category a {
+  text-decoration: none;
+  color: #818181;
+
+}
+
+#donut {
+  width: 200px;
+  order: 0;
+  position: relative;
+  float: left;
+  margin-right: 10px;
+  margin-bottom: 5px;
+}
 
 /* Footer */
 
 footer {
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    height: 30px;
-    width: 100vw;
-    padding-top: 5px;
-    background-color: #DB93D2;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 30px;
+  width: 100vw;
+  padding-top: 5px;
+  background-color: #DB93D2;
 }
 
 footer ul {
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-    margin-right: 160px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  margin-right: 160px;
 }
 
 /* Social Links */
 
 #social-links li {
-    text-decoration: none;
-    list-style-type: none;
+  text-decoration: none;
+  list-style-type: none;
 }
 
 #social-links li a i {
-    color: #111;
-    font-size: 24px;
+  color: #111;
+  font-size: 24px;
 }

--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="assets/css/style.css">
+
     <script src="https://kit.fontawesome.com/abff2078e5.js" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="assets/css/style.css">
     <title>Belgian Bakes</title>
 </head>
 
@@ -30,6 +31,7 @@
             <div class="category">
                 <div class="cat1">
                     <a href="#">
+                        <img id="donut" src="assets/images/kobby-mendez-WXJ33HOrzvE-unsplash.jpg" alt="">
                         <h2>Sweets</h2>
                         <p>Belgium is renowned for its delectable, sweet bakery treats. From classic favourites like
                             waffles and speculoos cookies. Belgian sweet bakery foods offer a delightful blend of

--- a/index.html
+++ b/index.html
@@ -28,40 +28,55 @@
 
             <div class="hero-image"></div>
 
-            <div class="category">
-                <div class="cat1">
-                    <a href="#">
-                        <img id="donut" src="assets/images/kobby-mendez-WXJ33HOrzvE-unsplash.jpg" alt="">
-                        <h2>Sweets</h2>
-                        <p>Belgium is renowned for its delectable, sweet bakery treats. From classic favourites like
-                            waffles and speculoos cookies. Belgian sweet bakery foods offer a delightful blend of
-                            flavours and textures. Whether you're looking to recreate these delicacies in your own
-                            kitchen or simply want to indulge in some foodie daydreaming, exploring the world of Belgian
-                            sweet bakery will surely leave you yearning for a sweet treat.</p>
-                    </a>
+            <main>
+
+                <div class="category">
+                    <div class="cat1">
+                        <a href="#">
+                            <img id="donut" src="assets/images/kobby-mendez-WXJ33HOrzvE-unsplash.jpg" alt="">
+                            <h2>Sweets</h2>
+                            <p>Belgium is renowned for its delectable, sweet bakery treats. From classic favourites like
+                                waffles and speculoos cookies. Belgian sweet bakery foods offer a delightful blend of
+                                flavours and textures. Whether you're looking to recreate these delicacies in your own
+                                kitchen or simply want to indulge in some foodie daydreaming, exploring the world of
+                                Belgian
+                                sweet bakery will surely leave you yearning for a sweet treat.</p>
+                        </a>
+                    </div>
+
+                    <div class="cat2">
+                        <a href="">
+                            <h2>Savoury</h2>
+                            <p>Belgium is also famous for its flavourful and delicious selection of savory baked goods
+                                that
+                                are a true delight to devour. From flaky, buttery croissants to delicious savory tarts
+                                and
+                                pastries, the Belgian bakery scene offers an array of options. Whatever you're craving,
+                                the
+                                classic savory bakery foods of Belgium are sure to satisfy your taste buds. Explore
+                                these
+                                delicious treats and bring a taste of Belgium to your kitchen.</p>
+                        </a>
+                    </div>
+                    
+                    <div class="cat3">
+                        <a href="">
+                            <h2>Snacks</h2>
+                            <p>Explore delicious Belgian snacks that are perfect for any occasion. Whether you're
+                                looking
+                                for sweet, savory or both options, Belgium offers a wide variety of snacks that will
+                                delight
+                                your taste buds and transport you to the heart of Europe's culinary delights.
+                                From flaky, buttery croissants to delicious savory tarts
+                            </p>
+                        </a>
+                    </div>
                 </div>
-                <div class="cat2">
-                    <a href="">
-                        <h2>Savoury</h2>
-                        <p>Belgium is also famous for its flavourful and delicious selection of savory baked goods that
-                            are a true delight to devour. From flaky, buttery croissants to delicious savory tarts and
-                            pastries, the Belgian bakery scene offers an array of options. Whatever you're craving, the
-                            classic savory bakery foods of Belgium are sure to satisfy your taste buds. Explore these
-                            delicious treats and bring a taste of Belgium to your kitchen.</p>
-                    </a>
-                </div>
-                <div class="cat3">
-                    <a href="">
-                        <h2>Snacks</h2>
-                        <p>Explore delicious Belgian snacks that are perfect for any occasion. Whether you're looking
-                            for sweet, savory or both options, Belgium offers a wide variety of snacks that will delight
-                            your taste buds and transport you to the heart of Europe's culinary delights.
-                            From flaky, buttery croissants to delicious savory tarts
-                        </p>
-                    </a>
-                </div>
-            </div>
+
+            </main>
+
         </div>
+
     </div>
 
     <footer>


### PR DESCRIPTION
put in the donut image in cat1.
moved CSS rules around to match the sections, made comments stand out more as you scroll past.
filtered out some redundant CSS rules by absorbing them into their parent selector
f.e. put font-family in .main-content, so we don't have to repeat the font-family in each text element. made sure it did not overwrite the header title.

you might see a lot of red, feel free to look around, it (should?) mainly be me moving rules around and only a few actual deletions.
